### PR TITLE
Fix extension packaging

### DIFF
--- a/BreastImplantAnalyzer/CMakeLists.txt
+++ b/BreastImplantAnalyzer/CMakeLists.txt
@@ -1,5 +1,5 @@
 #-----------------------------------------------------------------------------
-set(MODULE_NAME ImplantSizer)
+set(MODULE_NAME BreastImplantAnalyzer)
 
 #-----------------------------------------------------------------------------
 set(MODULE_PYTHON_SCRIPTS

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A 3D Slicer extension for analyzing breast implants. Current functionality inclu
 
 4.5. To try the module, "MRBreastImplant" sample data set can be used.
 
-5. Switch to the ImplantSizer module
+5. Switch to the Breast Implant Analyzer module
 
 ![Alt text](img/module.PNG?raw=true "Switch to module")
 


### PR DESCRIPTION
Fixes the error reported on the dashboard: http://slicer.cdash.org/viewConfigure.php?buildid=1954275

-- Configuring Scripted module: ImplantSizer
CMake Error at D:/D/P/Slicer-0/CMake/SlicerMacroBuildScriptedModule.cmake:78 (message):
  slicerMacroBuildScriptedModule(SCRIPTS) given nonexistent file or directory
  'ImplantSizer.py'
Call Stack (most recent call first):
  BreastImplantAnalyzer/CMakeLists.txt:16 (slicerMacroBuildScriptedModule)