### PR TITLE
Fix minor URL and documentation issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@ project(BreastImplantAnalyzer)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "https://github.com/lassoan/SlicerBreastImplantAnalyzer")
+set(EXTENSION_HOMEPAGE "https://github.com/lassoan/SlicerBreastImplantAnalyzer#breastimplantanalyzer")
 set(EXTENSION_CATEGORY "Quantification")
-set(EXTENSION_CONTRIBUTORS "Lance Levine (University of Miami Miller School of Medicine), Marc Levine, Dr. Wrood Kassira (University of Miami Department of Plastic Surgery)")
-set(EXTENSION_DESCRIPTION "A 3D Slicer extension for analyzing volume of breast implants.")
+set(EXTENSION_CONTRIBUTORS "Lance Levine (University of Miami Miller School of Medicine), Marc Levine (Penn State University College of Medicine), Dr. Wrood Kassira (University of Miami Department of Plastic & Reconstructive Surgery)")
+set(EXTENSION_DESCRIPTION "This extension allows the user to calculate the volume of a breast implant from breast MRI data with minimal user input.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/lancelevine/SlicerBreastImplantAnalyzer/master/BreastImplantAnalyzer.png")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/lancelevine/SlicerBreastImplantAnalyzer/master/Screenshot01.PNG")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(BreastImplantAnalyzer)
 set(EXTENSION_HOMEPAGE "https://github.com/lassoan/SlicerBreastImplantAnalyzer")
 set(EXTENSION_CATEGORY "Quantification")
 set(EXTENSION_CONTRIBUTORS "Lance Levine (University of Miami Miller School of Medicine), Marc Levine, Dr. Wrood Kassira (University of Miami Department of Plastic Surgery)")
-set(EXTENSION_DESCRIPTION "This is an example of a simple extension")
+set(EXTENSION_DESCRIPTION "A 3D Slicer extension for analyzing volume of breast implants.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/lancelevine/SlicerBreastImplantAnalyzer/master/BreastImplantAnalyzer.png")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/lancelevine/SlicerBreastImplantAnalyzer/master/Screenshot01.PNG")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(BreastImplantAnalyzer)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "https://www.slicer.org/wiki/Documentation/Nightly/Extensions/BreastImplantAnalyzer")
+set(EXTENSION_HOMEPAGE "https://github.com/lassoan/SlicerBreastImplantAnalyzer")
 set(EXTENSION_CATEGORY "Quantification")
 set(EXTENSION_CONTRIBUTORS "Lance Levine (University of Miami Miller School of Medicine), Marc Levine, Dr. Wrood Kassira (University of Miami Department of Plastic Surgery)")
 set(EXTENSION_DESCRIPTION "This is an example of a simple extension")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,8 @@ set(EXTENSION_HOMEPAGE "https://www.slicer.org/wiki/Documentation/Nightly/Extens
 set(EXTENSION_CATEGORY "Quantification")
 set(EXTENSION_CONTRIBUTORS "Lance Levine (University of Miami Miller School of Medicine), Marc Levine, Dr. Wrood Kassira (University of Miami Department of Plastic Surgery)")
 set(EXTENSION_DESCRIPTION "This is an example of a simple extension")
-set(EXTENSION_ICONURL "http://www.example.com/Slicer/Extensions/BreastImplantAnalyzer.png")
-set(EXTENSION_SCREENSHOTURLS "http://www.example.com/Slicer/Extensions/BreastImplantAnalyzer/Screenshots/1.png")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/lancelevine/SlicerBreastImplantAnalyzer/master/BreastImplantAnalyzer.png")
+set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/lancelevine/SlicerBreastImplantAnalyzer/master/Screenshot01.PNG")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # BreastImplantAnalyzer
 A 3D Slicer extension for analyzing breast implants. Current functionality includes volume calculation.
 
+Details of the extension are provided in: *L. Levine, W. Kassira, "BreastImplantAnalyzer: An Easy-to-use, Validated Tool for Calculating Breast Implant Volume from MRI Data", Journal of Plastic, Reconstructive & Aesthetic Surgery, 2021, [DOI](https://doi.org/10.1016/j.bjps.2021.03.068), [ScienceDirect](https://www.sciencedirect.com/science/article/pii/S1748681521001583)*
+
 ![Alt text](Screenshot01.PNG?raw=true "BreastImplantAnalyzer User Interface")
 
 ## Installation
 
+Standalone installation package is available at https://www.breastimplantanalyzer.com/.
+
+Alternatively, the tool can be installed as an extension to 3D Slicer:
 * Download and install the latest preview release version of 3D Slicer (https://download.slicer.org).
 * Start 3D Slicer application, open the Extension Manager (menu: View / Extension manager)
 * Install BreastImplantAnalyzer extension.


### PR DESCRIPTION
Until this gets merged, Slicer extension is built from the https://github.com/lassoan/SlicerBreastImplantAnalyzer fork.